### PR TITLE
rewrite psgr creation for more accurate demands

### DIFF
--- a/sim_list_builder.py
+++ b/sim_list_builder.py
@@ -1,52 +1,89 @@
-import random
+import numpy as np
 from datetime import datetime
 import json
 
 
 def build_simulation_list(floors:int, psgrs:int, max_time:int) -> str:
     
-    sim_list = []
+    psgrs_20_pct = int(.2 * psgrs)
+    psgrs_10_pct = int(.1 * psgrs)
+    psgrs_remain = psgrs - (3 * psgrs_20_pct) - (2 * psgrs_10_pct)
+
+    psgr_types = [{'psgr_type':'morning_rush','psgrs':psgrs_20_pct,'time_range':[0,.1*max_time]},
+                    {'psgr_type':'evening_rush','psgrs':psgrs_20_pct,'time_range':[.9*max_time,max_time]},
+                    {'psgr_type':'pre_lunch','psgrs':psgrs_10_pct,'time_range':[.45*max_time,.5*max_time]},
+                    {'psgr_type':'post_lunch','psgrs':psgrs_10_pct,'time_range':[.5*max_time,.55*max_time]},
+                    {'psgr_type':'off_times_am','psgrs':psgrs_20_pct,'time_range':[.1*max_time,.45*max_time]},
+                    {'psgr_type':'off_times_pm','psgrs':psgrs_remain,'time_range':[.55*max_time,.9*max_time]}]
+
     time_str = datetime.now().strftime("%Y_%m_%d_%H%M%S")
     sim_list_filename = f"input/simulation_list_{time_str}.json"
-
-    for i in range(psgrs):
-        psgr = {}
-        psgr['time'] = random.randrange(0, max_time, 1)
-        psgr['id'] = f"psgr{i}"
-        floor1 = random.randint(1,floors)
-        floor2 = random.choice([f for f in range(1,floors) if f != floor1])
-        psgr_dir = choose_direction()
-        if psgr_dir == 1:
-            psgr['source'],psgr['dest'] = floor1, floor2
-        else:
-            psgr['source'],psgr['dest'] = floor2, floor1
-        sim_list.append(psgr)
-        # print(psgr)
+    sim_list = []
+    
+    for p in psgr_types:
+        for i in range(p['psgrs']):
+            sim_list.append(create_passenger(i, floors, max_time, p))
 
     with open(sim_list_filename, 'w') as sim_list_file:
         json.dump(sim_list,sim_list_file)
 
+    print(sim_list)
     return sim_list_filename
-        
-
-def choose_direction():
-    n = random.randint(1,10)
-    return 1 if n > 5 else -1
-        
-
-def choose_source(floors:int, direction:int):
-    max_floor = floors - 1 if direction == 1 else floors
-    return random.randrange(1, max_floor, 1)
 
 
-def choose_destination(floors:int, 
-                       curr_floor:int, 
-                       direction:int):
-    if direction == 1:
-        dest_floor = random.randrange(curr_floor + 1, floors, 1)
+def create_passenger(i:int, floors:int, max_time:int, psgr_type:dict) -> dict:
+
+    print("creating passenger...")
+    psgr_dict = {}
+    psgr_dict['time'] = get_time_tick(psgr_type)
+    psgr_dict['source'] = get_source_floor(floors, psgr_type)
+    psgr_dict['dest'] = get_dest_floor(psgr_dict['source'], floors, psgr_type)
+    psgr_dict['id'] = f"psgr_{psgr_type['psgr_type']}_{i}"
+    print(f"created passenger {psgr_dict}")
+    return psgr_dict
+
+
+def get_time_tick(psgr_type:dict) -> int:
+    time_tick = 0
+    rng = np.random.default_rng()
+
+    if psgr_type['psgr_type']=='morning_rush':
+        time_tick = int(np.random.triangular(psgr_type['time_range'][0],
+                                                         psgr_type['time_range'][0] + 1,
+                                                         psgr_type['time_range'][1]))
+    elif psgr_type['psgr_type']=='evening_rush':
+        time_tick = int(np.random.triangular(psgr_type['time_range'][0],
+                                                         psgr_type['time_range'][1] - 1,
+                                                         psgr_type['time_range'][1]))
     else:
-        dest_floor = random.randrange(curr_floor - 1, 1, -1)
-        
+        time_tick = int(rng.integers(psgr_type['time_range'][0],
+                                psgr_type['time_range'][1] + 1))
+    
+    return time_tick
+
+
+def get_source_floor(floors:int, psgr_type:dict):
+    floor_num = 0
+    rng = np.random.default_rng()
+
+    if psgr_type['psgr_type']=='morning_rush' or psgr_type['psgr_type']=='post_lunch':
+        floor_num = 1
+    else:
+        floor_num = int(rng.integers(2,floors + 1))
+
+    return floor_num
+
+
+def get_dest_floor(source_floor:int, floors:int, psgr_type:dict):
+    floor_num = 0
+    
+    if psgr_type['psgr_type']=='evening_rush' or psgr_type['psgr_type']=='pre_lunch':
+        floor_num = 1
+    else:
+        floor_num = int(np.random.choice(list(set([x for x in range(2,floors + 1)]) - set([source_floor]))))
+
+    return floor_num
+
 
 def main():
     floors = 10


### PR DESCRIPTION
rewrote the simulation passenger list builder to use more accurate randomness and more likely elevator demands based on time of day - assuming the time ticks for a simulation represent a single day's activity

Early morning riders are starting at floor 1 and going to some floor, while end of time period riders are heading towards floor 1.  There is also a downward rush at the start of lunch, accompanied by an upward rush at the end of lunch.  Randomness is skewed in these cases to simulate these rushes more accurately.

The "off times" make use of random generation of source and destination floors, to show more varied rider behavior during these periods.  Might make sense to model even these times as favored toward floor 1 as source or destination, but that is not addressed in this change.